### PR TITLE
Stop packaging screenshots

### DIFF
--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  ignoreFiles: [
+    'images/Screen*.png',
+  ],
+};


### PR DESCRIPTION
These don't seem to be actually used, so this reduces the extensions size from ~1.3M to 80K.