### PR TITLE
feat(): Add support for redirecting to the old Reddit desktop or mobile design

### DIFF
--- a/background.js
+++ b/background.js
@@ -505,7 +505,7 @@ function redirectReddit(url, initiator, type) {
   if (initiator && initiator.origin === oldRedditView || url.origin === oldRedditView) {
     return null;
   }
-  // Do not redirect anything other than main_frame
+  // Do not redirect exclusions nor anything other than main_frame
   if (type !== "main_frame" || url.pathname.match(redditBypassPaths)) {
     return null;
   }

--- a/background.js
+++ b/background.js
@@ -84,6 +84,18 @@ const bibliogramInstances = [
   "https://bibliogram.ggc-project.de",
 ];
 const osmDefault = "https://openstreetmap.org";
+const redditDomains = [
+  "www.reddit.com",
+  "np.reddit.com",
+  "new.reddit.com",
+  "amp.reddit.com"
+];
+const redditBypassPaths = /\/(gallery\/poll\/rpan\/settings\/topics)/;
+const redditVersions = [
+  "https://old.reddit.com",
+  "https://i.reddit.com" // Old Mobile view
+];
+const redditDefault = redditVersions[0];
 const googleMapsRegex = /https?:\/\/(((www|maps)\.)?(google\.).*(\/maps)|maps\.(google\.).*)/;
 const mapCentreRegex = /@(-?\d[0-9.]*),(-?\d[0-9.]*),(\d{1,2})[.z]/;
 const dataLatLngRegex = /(!3d|!4d)(-?[0-9]{1,10}.[0-9]{1,10})/g;
@@ -105,10 +117,12 @@ let disableNitter;
 let disableInvidious;
 let disableBibliogram;
 let disableOsm;
+let disableRedditVersion;
 let nitterInstance;
 let invidiousInstance;
 let bibliogramInstance;
 let osmInstance;
+let redditVersion;
 let alwaysProxy;
 let onlyEmbeddedVideo;
 let videoQuality;
@@ -127,10 +141,12 @@ browser.storage.sync.get(
     "invidiousInstance",
     "bibliogramInstance",
     "osmInstance",
+    "redditVersion",
     "disableNitter",
     "disableInvidious",
     "disableBibliogram",
     "disableOsm",
+    "disableRedditVersion",
     "alwaysProxy",
     "onlyEmbeddedVideo",
     "videoQuality",
@@ -146,10 +162,12 @@ browser.storage.sync.get(
     disableInvidious = result.disableInvidious;
     disableBibliogram = result.disableBibliogram;
     disableOsm = result.disableOsm;
+    disableRedditVersion = result.disableRedditVersion;
     nitterInstance = result.nitterInstance;
     invidiousInstance = result.invidiousInstance;
     bibliogramInstance = result.bibliogramInstance;
     osmInstance = result.osmInstance || osmDefault;
+    redditVersion = result.redditVersion || redditDefault;
     alwaysProxy = result.alwaysProxy;
     onlyEmbeddedVideo = result.onlyEmbeddedVideo;
     videoQuality = result.videoQuality;
@@ -179,6 +197,9 @@ browser.storage.onChanged.addListener((changes) => {
   if ("osmInstance" in changes) {
     osmInstance = changes.osmInstance.newValue || osmDefault;
   }
+  if ("redditVersion" in changes) {
+    redditVersion = changes.redditVersion.newValue || redditDefault;
+  }
   if ("disableNitter" in changes) {
     disableNitter = changes.disableNitter.newValue;
   }
@@ -190,6 +211,9 @@ browser.storage.onChanged.addListener((changes) => {
   }
   if ("disableOsm" in changes) {
     disableOsm = changes.disableOsm.newValue;
+  }
+  if ("disableRedditVersion" in changes) {
+    disableRedditVersion = changes.disableRedditVersion.newValue;
   }
   if ("alwaysProxy" in changes) {
     alwaysProxy = changes.alwaysProxy.newValue;
@@ -473,6 +497,26 @@ function redirectGoogleMaps(url, initiator) {
   return redirect;
 }
 
+function redirectReddit(url, initiator, type) {
+  if (disableRedditVersion || isException(url, initiator)) {
+    return null;
+  }
+  // Do not redirect old or mobile Reddit versions on normal Reddit links
+  if (
+    initiator &&
+    (initiator.origin === redditVersion ||
+      redditVersions.includes(initiator.origin) ||
+      redditVersions.includes(initiator.host))
+  ) {
+    return null;
+  }
+  // Do not redirect anything other than main_frame
+  if (type !== "main_frame" || url.pathname.match(redditBypassPaths)) {
+    return null;
+  }
+  return `${redditVersion}${url.pathname}${url.search}`;
+}
+
 browser.webRequest.onBeforeRequest.addListener(
   (details) => {
     const url = new URL(details.url);
@@ -499,6 +543,10 @@ browser.webRequest.onBeforeRequest.addListener(
       redirect = {
         redirectUrl: redirectGoogleMaps(url, initiator),
       };
+    } else if (redditDomains.includes(url.host)) {
+      redirect = {
+        redirectUrl: redirectReddit(url, initiator, details.type),
+      }
     }
     if (redirect && redirect.redirectUrl) {
       console.info(

--- a/background.js
+++ b/background.js
@@ -95,7 +95,7 @@ const oldRedditViews = [
   "https://old.reddit.com", // desktop
   "https://i.reddit.com" // mobile
 ];
-const redditDefault = oldRedditViews[0];
+const oldRedditDefaultView = oldRedditViews[0];
 const googleMapsRegex = /https?:\/\/(((www|maps)\.)?(google\.).*(\/maps)|maps\.(google\.).*)/;
 const mapCentreRegex = /@(-?\d[0-9.]*),(-?\d[0-9.]*),(\d{1,2})[.z]/;
 const dataLatLngRegex = /(!3d|!4d)(-?[0-9]{1,10}.[0-9]{1,10})/g;
@@ -167,7 +167,7 @@ browser.storage.sync.get(
     invidiousInstance = result.invidiousInstance;
     bibliogramInstance = result.bibliogramInstance;
     osmInstance = result.osmInstance || osmDefault;
-    oldRedditView = result.oldRedditView || redditDefault;
+    oldRedditView = result.oldRedditView || oldRedditDefaultView;
     alwaysProxy = result.alwaysProxy;
     onlyEmbeddedVideo = result.onlyEmbeddedVideo;
     videoQuality = result.videoQuality;
@@ -198,7 +198,7 @@ browser.storage.onChanged.addListener((changes) => {
     osmInstance = changes.osmInstance.newValue || osmDefault;
   }
   if ("oldRedditView" in changes) {
-    oldRedditView = changes.oldRedditView.newValue || redditDefault;
+    oldRedditView = changes.oldRedditView.newValue || oldRedditDefaultView;
   }
   if ("disableNitter" in changes) {
     disableNitter = changes.disableNitter.newValue;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.1.41",
+  "version": "1.1.42",
   "manifest_version": 2,
   "background": {
     "scripts": ["background.js"],

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -121,6 +121,28 @@
         </table>
       </section>
       <section class="settings-block">
+        <table class="option" aria-label="Toggle Reddit version redirects">
+          <tbody>
+            <tr>
+              <td>
+                <h1 data-localise="__MSG_disableRedditVersion__">
+                  Reddit Version Redirects
+                </h1>
+              </td>
+              <td>
+                <input
+                  aria-hidden="true"
+                  id="disable-reddit-version"
+                  type="checkbox"
+                  checked
+                />&nbsp;
+                <label for="disable-reddit-version" class="checkbox-label"> </label>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="settings-block">
         <h1 data-localise="__MSG_nitterInstance__">Nitter Instance</h1>
         <div class="autocomplete">
           <input
@@ -158,6 +180,16 @@
             id="osm-instance"
             type="url"
             placeholder="https://openstreetmap.org"
+          />
+        </div>
+      </section>
+      <section class="settings-block">
+        <h1 data-localise="__MSG_redditVersion__">Reddit Version</h1>
+        <div class="autocomplete">
+          <input
+            id="reddit-version"
+            type="url"
+            placeholder="https://old.reddit.com"
           />
         </div>
       </section>

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -121,22 +121,22 @@
         </table>
       </section>
       <section class="settings-block">
-        <table class="option" aria-label="Toggle Reddit version redirects">
+        <table class="option" aria-label="Toggle old Reddit redirects">
           <tbody>
             <tr>
               <td>
-                <h1 data-localise="__MSG_disableRedditVersion__">
-                  Reddit Version Redirects
+                <h1 data-localise="__MSG_disableOldReddit__">
+                  Old Reddit Redirects
                 </h1>
               </td>
               <td>
                 <input
                   aria-hidden="true"
-                  id="disable-reddit-version"
+                  id="disable-old-reddit"
                   type="checkbox"
                   checked
                 />&nbsp;
-                <label for="disable-reddit-version" class="checkbox-label"> </label>
+                <label for="disable-old-reddit" class="checkbox-label"> </label>
               </td>
             </tr>
           </tbody>
@@ -184,10 +184,10 @@
         </div>
       </section>
       <section class="settings-block">
-        <h1 data-localise="__MSG_redditVersion__">Reddit Version</h1>
+        <h1 data-localise="__MSG_oldRedditView__">Old Reddit View (Desktop or Mobile)</h1>
         <div class="autocomplete">
           <input
-            id="reddit-version"
+            id="old-reddit-view"
             type="url"
             placeholder="https://old.reddit.com"
           />

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -45,21 +45,28 @@ const bibliogramInstances = [
   "https://bibliogram.ggc-project.de",
 ];
 const osmInstances = ["https://openstreetmap.org"];
+const redditVersions = [
+  "https://old.reddit.com",
+  "https://i.reddit.com"
+];
 const autocompletes = [
   { id: "nitter-instance", instances: nitterInstances },
   { id: "invidious-instance", instances: invidiousInstances },
   { id: "bibliogram-instance", instances: bibliogramInstances },
   { id: "osm-instance", instances: osmInstances },
+  { id: "reddit-version", instances: redditVersions },
 ];
 
 let nitterInstance = document.getElementById("nitter-instance");
 let invidiousInstance = document.getElementById("invidious-instance");
 let bibliogramInstance = document.getElementById("bibliogram-instance");
 let osmInstance = document.getElementById("osm-instance");
+let redditVersion = document.getElementById("reddit-version");
 let disableNitter = document.getElementById("disable-nitter");
 let disableInvidious = document.getElementById("disable-invidious");
 let disableBibliogram = document.getElementById("disable-bibliogram");
 let disableOsm = document.getElementById("disable-osm");
+let disableRedditVersion = document.getElementById("disable-reddit-version");
 let alwaysProxy = document.getElementById("always-proxy");
 let onlyEmbeddedVideo = document.getElementById("only-embed");
 let videoQuality = document.getElementById("video-quality");
@@ -103,10 +110,12 @@ browser.storage.sync.get(
     "invidiousInstance",
     "bibliogramInstance",
     "osmInstance",
+    "redditVersion",
     "disableNitter",
     "disableInvidious",
     "disableBibliogram",
     "disableOsm",
+    "disableRedditVersion",
     "alwaysProxy",
     "onlyEmbeddedVideo",
     "videoQuality",
@@ -127,10 +136,12 @@ browser.storage.sync.get(
     invidiousInstance.value = result.invidiousInstance || "";
     bibliogramInstance.value = result.bibliogramInstance || "";
     osmInstance.value = result.osmInstance || "";
+    redditVersion.value = result.redditVersion || "";
     disableNitter.checked = !result.disableNitter;
     disableInvidious.checked = !result.disableInvidious;
     disableBibliogram.checked = !result.disableBibliogram;
     disableOsm.checked = !result.disableOsm;
+    disableRedditVersion.checked = !result.disableRedditVersion;
     alwaysProxy.checked = result.alwaysProxy;
     onlyEmbeddedVideo.checked = result.onlyEmbeddedVideo;
     videoQuality.value = result.videoQuality || "";
@@ -273,6 +284,15 @@ let osmInstanceChange = debounce(() => {
 }, 500);
 osmInstance.addEventListener("input", osmInstanceChange);
 
+let redditVersionChange = debounce(() => {
+  if (redditVersion.checkValidity()) {
+    browser.storage.sync.set({
+      redditVersion: parseURL(redditVersion.value),
+    });
+  }
+}, 500);
+redditVersion.addEventListener("input", redditVersionChange);
+
 disableNitter.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableNitter: !event.target.checked });
 });
@@ -287,6 +307,10 @@ disableBibliogram.addEventListener("change", (event) => {
 
 disableOsm.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableOsm: !event.target.checked });
+});
+
+disableRedditVersion.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableRedditVersion: !event.target.checked });
 });
 
 alwaysProxy.addEventListener("change", (event) => {

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -45,28 +45,28 @@ const bibliogramInstances = [
   "https://bibliogram.ggc-project.de",
 ];
 const osmInstances = ["https://openstreetmap.org"];
-const redditVersions = [
-  "https://old.reddit.com",
-  "https://i.reddit.com"
+const oldRedditViews = [
+  "https://old.reddit.com", // desktop
+  "https://i.reddit.com" // mobile
 ];
 const autocompletes = [
   { id: "nitter-instance", instances: nitterInstances },
   { id: "invidious-instance", instances: invidiousInstances },
   { id: "bibliogram-instance", instances: bibliogramInstances },
   { id: "osm-instance", instances: osmInstances },
-  { id: "reddit-version", instances: redditVersions },
+  { id: "old-reddit-view", instances: oldRedditViews },
 ];
 
 let nitterInstance = document.getElementById("nitter-instance");
 let invidiousInstance = document.getElementById("invidious-instance");
 let bibliogramInstance = document.getElementById("bibliogram-instance");
 let osmInstance = document.getElementById("osm-instance");
-let redditVersion = document.getElementById("reddit-version");
+let oldRedditView = document.getElementById("old-reddit-view");
 let disableNitter = document.getElementById("disable-nitter");
 let disableInvidious = document.getElementById("disable-invidious");
 let disableBibliogram = document.getElementById("disable-bibliogram");
 let disableOsm = document.getElementById("disable-osm");
-let disableRedditVersion = document.getElementById("disable-reddit-version");
+let disableOldReddit = document.getElementById("disable-old-reddit");
 let alwaysProxy = document.getElementById("always-proxy");
 let onlyEmbeddedVideo = document.getElementById("only-embed");
 let videoQuality = document.getElementById("video-quality");
@@ -110,12 +110,12 @@ browser.storage.sync.get(
     "invidiousInstance",
     "bibliogramInstance",
     "osmInstance",
-    "redditVersion",
+    "oldRedditView",
     "disableNitter",
     "disableInvidious",
     "disableBibliogram",
     "disableOsm",
-    "disableRedditVersion",
+    "disableOldReddit",
     "alwaysProxy",
     "onlyEmbeddedVideo",
     "videoQuality",
@@ -136,12 +136,12 @@ browser.storage.sync.get(
     invidiousInstance.value = result.invidiousInstance || "";
     bibliogramInstance.value = result.bibliogramInstance || "";
     osmInstance.value = result.osmInstance || "";
-    redditVersion.value = result.redditVersion || "";
+    oldRedditView.value = result.oldRedditView || "";
     disableNitter.checked = !result.disableNitter;
     disableInvidious.checked = !result.disableInvidious;
     disableBibliogram.checked = !result.disableBibliogram;
     disableOsm.checked = !result.disableOsm;
-    disableRedditVersion.checked = !result.disableRedditVersion;
+    disableOldReddit.checked = !result.disableOldReddit;
     alwaysProxy.checked = result.alwaysProxy;
     onlyEmbeddedVideo.checked = result.onlyEmbeddedVideo;
     videoQuality.value = result.videoQuality || "";
@@ -284,14 +284,14 @@ let osmInstanceChange = debounce(() => {
 }, 500);
 osmInstance.addEventListener("input", osmInstanceChange);
 
-let redditVersionChange = debounce(() => {
-  if (redditVersion.checkValidity()) {
+let oldRedditViewChange = debounce(() => {
+  if (oldRedditView.checkValidity()) {
     browser.storage.sync.set({
-      redditVersion: parseURL(redditVersion.value),
+      oldRedditView: parseURL(oldRedditView.value),
     });
   }
 }, 500);
-redditVersion.addEventListener("input", redditVersionChange);
+oldRedditView.addEventListener("input", oldRedditViewChange);
 
 disableNitter.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableNitter: !event.target.checked });
@@ -309,8 +309,8 @@ disableOsm.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableOsm: !event.target.checked });
 });
 
-disableRedditVersion.addEventListener("change", (event) => {
-  browser.storage.sync.set({ disableRedditVersion: !event.target.checked });
+disableOldReddit.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableOldReddit: !event.target.checked });
 });
 
 alwaysProxy.addEventListener("change", (event) => {

--- a/pages/popup/popup.html
+++ b/pages/popup/popup.html
@@ -116,6 +116,29 @@
       </table>
     </section>
 
+    <section class="settings-block">
+      <table class="option" aria-label="Toggle Reddit version redirects">
+        <tbody>
+          <tr>
+            <td>
+              <h1 data-localise="__MSG_disableRedditVersion__">
+                Reddit Version Redirects
+              </h1>
+            </td>
+            <td>
+              <input
+                aria-hidden="true"
+                id="disable-reddit-version"
+                type="checkbox"
+                checked
+              />&nbsp;
+              <label for="disable-reddit-version" class="checkbox-label"> </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
     <section class="settings-block"></section>
 
     <footer>

--- a/pages/popup/popup.html
+++ b/pages/popup/popup.html
@@ -117,22 +117,22 @@
     </section>
 
     <section class="settings-block">
-      <table class="option" aria-label="Toggle Reddit version redirects">
+      <table class="option" aria-label="Toggle old Reddit redirects">
         <tbody>
           <tr>
             <td>
-              <h1 data-localise="__MSG_disableRedditVersion__">
-                Reddit Version Redirects
+              <h1 data-localise="__MSG_disableOldReddit__">
+                Old Reddit Redirects
               </h1>
             </td>
             <td>
               <input
                 aria-hidden="true"
-                id="disable-reddit-version"
+                id="disable-old-reddit"
                 type="checkbox"
                 checked
               />&nbsp;
-              <label for="disable-reddit-version" class="checkbox-label"> </label>
+              <label for="disable-old-reddit" class="checkbox-label"> </label>
             </td>
           </tr>
         </tbody>

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -4,7 +4,7 @@ let disableNitter = document.querySelector("#disable-nitter");
 let disableInvidious = document.querySelector("#disable-invidious");
 let disableBibliogram = document.querySelector("#disable-bibliogram");
 let disableOsm = document.querySelector("#disable-osm");
-let disableRedditVersion = document.querySelector("#disable-reddit-version");
+let disableOldReddit = document.querySelector("#disable-old-reddit");
 let version = document.querySelector("#version");
 
 window.browser = window.browser || window.chrome;
@@ -15,7 +15,7 @@ browser.storage.sync.get(
     "disableInvidious",
     "disableBibliogram",
     "disableOsm",
-    "disableRedditVersion",
+    "disableOldReddit",
     "theme",
   ],
   (result) => {
@@ -24,7 +24,7 @@ browser.storage.sync.get(
     disableInvidious.checked = !result.disableInvidious;
     disableBibliogram.checked = !result.disableBibliogram;
     disableOsm.checked = !result.disableOsm;
-    disableRedditVersion.checked = !result.disableRedditVersion;
+    disableOldReddit.checked = !result.disableOldReddit;
   }
 );
 
@@ -46,8 +46,8 @@ disableOsm.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableOsm: !event.target.checked });
 });
 
-disableRedditVersion.addEventListener("change", (event) => {
-  browser.storage.sync.set({ disableRedditVersion: !event.target.checked });
+disableOldReddit.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableOldReddit: !event.target.checked });
 });
 
 document.querySelector("#more-options").addEventListener("click", () => {

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -4,6 +4,7 @@ let disableNitter = document.querySelector("#disable-nitter");
 let disableInvidious = document.querySelector("#disable-invidious");
 let disableBibliogram = document.querySelector("#disable-bibliogram");
 let disableOsm = document.querySelector("#disable-osm");
+let disableRedditVersion = document.querySelector("#disable-reddit-version");
 let version = document.querySelector("#version");
 
 window.browser = window.browser || window.chrome;
@@ -14,6 +15,7 @@ browser.storage.sync.get(
     "disableInvidious",
     "disableBibliogram",
     "disableOsm",
+    "disableRedditVersion",
     "theme",
   ],
   (result) => {
@@ -22,6 +24,7 @@ browser.storage.sync.get(
     disableInvidious.checked = !result.disableInvidious;
     disableBibliogram.checked = !result.disableBibliogram;
     disableOsm.checked = !result.disableOsm;
+    disableRedditVersion.checked = !result.disableRedditVersion;
   }
 );
 
@@ -41,6 +44,10 @@ disableBibliogram.addEventListener("change", (event) => {
 
 disableOsm.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableOsm: !event.target.checked });
+});
+
+disableRedditVersion.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableRedditVersion: !event.target.checked });
 });
 
 document.querySelector("#more-options").addEventListener("click", () => {


### PR DESCRIPTION
### PR Description:
Adds support for redirecting Reddit links to the old desktop (https://old.reddit.com/) and mobile designs (https://i.reddit.com/) which serve _less_ JavaScript than the new design (https://www.reddit.com/). Also handles case where you're on an old view (i.e. i.reddit.com) and you update the settings to redirect to the _other_ old view (i.e. old.reddit.com).

Not sure if this is can really be counted as a privacy redirect since there isn't an alternative, privacy-forward Reddit interface so I would understand if this change isn't accepted. The UI for this change also doesn't feel very intuitive due to the fact we're redirecting to subdomains of the same service. But at least this is reference code for anyone who wants local support :smile: 

### Testing:
Validated in Chromium and Firefox.

### Screenshots:

![pr-popup](https://user-images.githubusercontent.com/1514352/92318852-f0c18980-efc6-11ea-9be3-e957e2b34192.png)

![pr-options](https://user-images.githubusercontent.com/1514352/92318854-f4551080-efc6-11ea-9daa-25a3318060d0.png)
