### PR TITLE
Add Teddit and Snew to reddit redirect options

### DIFF
--- a/background.js
+++ b/background.js
@@ -109,8 +109,10 @@ const redditDomains = [
 ];
 const redditBypassPaths = /\/(gallery\/poll\/rpan\/settings\/topics)/;
 const oldRedditViews = [
+  "https://teddit.net", // privacy
+  "https://snew.notabug.io", // anti-censorship
   "https://old.reddit.com", // desktop
-  "https://i.reddit.com", // mobile
+  "https://i.reddit.com" // mobile
 ];
 const oldRedditDefaultView = oldRedditViews[0];
 const googleMapsRegex = /https?:\/\/(((www|maps)\.)?(google\.).*(\/maps)|maps\.(google\.).*)/;


### PR DESCRIPTION
closes #137 

[Snew](https://snew.notabug.io) (aka. "ceddit") allows viewing posts/comments that are deleted by moderators. It is [open source](https://github.com/snew/snew) but still pings reddit.

also you need to remove the "Old" from "Old Reddit Redirects" after this PR