### PR TITLE
Add Presearch search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Privacy Redirect allows setting custom instances, instances can be found here:
   - [Startpage](https://startpage.com)
   - [Qwant](https://www.qwant.com)
   - [Mojeek](https://www.mojeek.com)
+  - [Presearch](https://www.presearch.org)
 
 ## Development
 

--- a/src/assets/javascripts/helpers/google-search.js
+++ b/src/assets/javascripts/helpers/google-search.js
@@ -11,6 +11,7 @@ const redirects = [
   { link: "https://searx.tuxcloud.net", q: "/" },
   { link: "https://searx.ninja", q: "/" },
   { link: "https://tromland.org/searx", q: "/search" },
+  { link: "https://engine.presearch.org", q: "/search" },
 ];
 
 export default {


### PR DESCRIPTION
Hi, are you willing to add [Presearch](https://www.presearch.io) as an alternative to Google?

TL;DR: Privacy-centric, shares ad revenue with users & node operators, aims to become open-source and powered by various types of nodes run by users, governed by DAO. Currently closed-source, centralized and only the first type of node is rolling out soon.

They had a surge of popularity recently, probably due to Google banning Element, Google removing Robinhood reviews and user nodes coming soon.