### PR TITLE
Update Bibliogram instances list

### DIFF
--- a/src/assets/javascripts/helpers/instagram.js
+++ b/src/assets/javascripts/helpers/instagram.js
@@ -9,13 +9,8 @@ const redirects = [
   "https://bibliogram.snopyta.org",
   "https://bibliogram.pussthecat.org",
   "https://bibliogram.nixnet.services",
-  "https://bg.endl.site",
-  "https://bibliogram.13ad.de",
-  "https://bibliogram.pixelfed.uno",
   "https://bibliogram.ethibox.fr",
-  "https://bibliogram.hamster.dance",
-  "https://bibliogram.kavin.rocks",
-  "https://bibliogram.ggc-project.de",
+  "https://bibliogram.hamster.dance"
 ];
 const reservedPaths = [
   "about",


### PR DESCRIPTION
It now matches the list of actually working instances.

The list is here: https://git.sr.ht/~cadence/bibliogram-docs/tree/master/docs/Instances.md