### PR TITLE
Redirect reddit images for libreddit instances

### DIFF
--- a/src/assets/javascripts/helpers/reddit.js
+++ b/src/assets/javascripts/helpers/reddit.js
@@ -3,6 +3,7 @@ const targets = [
   "np.reddit.com",
   "new.reddit.com",
   "amp.reddit.com",
+  "i.redd.it",
 ];
 const redirects = [
   // libreddit: privacy w/ modern UI

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -454,6 +454,8 @@ function redirectReddit(url, initiator, type) {
     } else if (redditInstance.includes("teddit")) {
       let pathWithoutSlash = url.pathname.slice(1);
       return `${redditInstance}/pics/w:null_${pathWithoutSlash}${url.search}`
+    } else {
+      return null;
     }
   }
   return `${redditInstance}${url.pathname}${url.search}`;

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -448,6 +448,9 @@ function redirectReddit(url, initiator, type) {
   if (type !== "main_frame" || url.pathname.match(redditBypassPaths)) {
     return null;
   }
+  if (url.host === "i.redd.it") {
+    return `${redditInstance}/img${url.pathname}${url.search}`;
+  }
   return `${redditInstance}${url.pathname}${url.search}`;
 }
 

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -449,7 +449,12 @@ function redirectReddit(url, initiator, type) {
     return null;
   }
   if (url.host === "i.redd.it") {
-    return `${redditInstance}/img${url.pathname}${url.search}`;
+    if (redditInstance.includes("libredd")) {
+      return `${redditInstance}/img${url.pathname}${url.search}`;
+    } else if (redditInstance.includes("teddit")) {
+      let pathWithoutSlash = url.pathname.slice(1);
+      return `${redditInstance}/pics/w:null_${pathWithoutSlash}${url.search}`
+    }
   }
   return `${redditInstance}${url.pathname}${url.search}`;
 }

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -452,8 +452,12 @@ function redirectReddit(url, initiator, type) {
     if (redditInstance.includes("libredd")) {
       return `${redditInstance}/img${url.pathname}${url.search}`;
     } else if (redditInstance.includes("teddit")) {
-      let pathWithoutSlash = url.pathname.slice(1);
-      return `${redditInstance}/pics/w:null_${pathWithoutSlash}${url.search}`
+      // As of 2021-04-09, redirects for teddit images are nontrivial:
+      // - navigating to the image before ever navigating to its page causes
+      //   404 error (probably needs fix on teddit project)
+      // - some image links on teddit are very different
+      // Therefore, don't support redirecting image links for teddit.
+      return null;
     } else {
       return null;
     }


### PR DESCRIPTION
Reddit image urls look like "i.redd.it/abc123.jpg".

- libreddit: redirect these urls to "<hostname>/img/abc123.jpg"
- teddit: don't redirect
- other: don't redirect

Don't support teddit because there are some issues, even though
"<hostname>/pics/w:null_abc123.jpg" could sometimes work:

- if the page containing the image isn't ever visited on the instance,
  visiting the image directly results in a 404 error
- sometimes, the image url is not "abc123.jpg" but something else