### PR TITLE
Redirect redd.it

### DIFF
--- a/src/assets/javascripts/helpers/reddit.js
+++ b/src/assets/javascripts/helpers/reddit.js
@@ -4,6 +4,7 @@ const targets = [
   "new.reddit.com",
   "amp.reddit.com",
   "i.redd.it",
+  "redd.it",
 ];
 const redirects = [
   // libreddit: privacy w/ modern UI

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -483,9 +483,15 @@ function redirectReddit(url, initiator, type) {
       return null;
     }
   } else if (url.host === "redd.it") {
-    if (redditInstance.includes("teddit")) {
-      // As of 2021-04-22, redirects for teddit redd.it links don't work out of
-      // the box.  Prefixing the path with "/comments" seems to help.
+    if (
+      redditInstance.includes("teddit") &&
+      !url.pathname.startsWith("/comments/")
+    ) {
+      // As of 2021-04-22, redirects for teddit redd.it links don't work unless
+      // the path starts with "/comments".  It appears that all links that
+      // don't start with "/comments" are interchangeable with the ones
+      // that do start with "/comments", so manually add that prefix if it is
+      // missing.
       return `${redditInstance}/comments${url.pathname}${url.search}`;
     }
   }

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -482,6 +482,12 @@ function redirectReddit(url, initiator, type) {
     } else {
       return null;
     }
+  } else if (url.host === "redd.it") {
+    if (redditInstance.includes("teddit")) {
+      // As of 2021-04-22, redirects for teddit on redd.it links don't work:
+      // they take you to the home page.
+      return null;
+    }
   }
   return `${redditInstance}${url.pathname}${url.search}`;
 }

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -485,7 +485,7 @@ function redirectReddit(url, initiator, type) {
   } else if (url.host === "redd.it") {
     if (
       redditInstance.includes("teddit") &&
-      !url.pathname.startsWith("/comments/")
+      !url.pathname.match(/^\/\S+\//)
     ) {
       // As of 2021-04-22, redirects for teddit redd.it links don't work unless
       // the path starts with "/comments".  It appears that all links that

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -485,13 +485,16 @@ function redirectReddit(url, initiator, type) {
   } else if (url.host === "redd.it") {
     if (
       redditInstance.includes("teddit") &&
-      !url.pathname.match(/^\/\S+\//)
+      !url.pathname.match(/^\/+[^\/]+\/+[^\/]/)
     ) {
-      // As of 2021-04-22, redirects for teddit redd.it links don't work unless
-      // the path starts with "/comments".  It appears that all links that
-      // don't start with "/comments" are interchangeable with the ones
-      // that do start with "/comments", so manually add that prefix if it is
-      // missing.
+      // As of 2021-04-22, redirects for teddit redd.it/foo links don't work.
+      // It appears that adding "/comments" as a prefix works, so manually add
+      // that prefix if it is missing.  Even though redd.it/comments/foo links
+      // don't seem to work or exist, guard against affecting those kinds of
+      // paths.
+      //
+      // Note the difference between redd.it/comments/foo (doesn't work) and
+      // teddit.net/comments/foo (works).
       return `${redditInstance}/comments${url.pathname}${url.search}`;
     }
   }

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -484,9 +484,9 @@ function redirectReddit(url, initiator, type) {
     }
   } else if (url.host === "redd.it") {
     if (redditInstance.includes("teddit")) {
-      // As of 2021-04-22, redirects for teddit on redd.it links don't work:
-      // they take you to the home page.
-      return null;
+      // As of 2021-04-22, redirects for teddit redd.it links don't work out of
+      // the box.  Prefixing the path with "/comments" seems to help.
+      return `${redditInstance}/comments${url.pathname}${url.search}`;
     }
   }
   return `${redditInstance}${url.pathname}${url.search}`;


### PR DESCRIPTION
If you try visiting a redd.it site like <https://redd.it/1fwqjw> (first
link that came up when searching "site:redd.it"), you may think that the
redirect works because it goes to your configured instance.  However,
there's a leak: redd.it is a redirect to a www.reddit.com site, and
that's when the redirect to instance happens.  If you observe the
network traffic, you'll see that a GET request goes to redd.it, and
redd.it returns HTTP code 302 and location https://www.reddit.com/...

Let's not do that.  Redirect before redd.it so that requests don't hit
reddit servers.  For teddit instances, prefix the path with "/comments"
because it otherwise redirects to the home page.

Tested on

- libredd.it
- teddit.net
- old.reddit.com
- i.reddit.com