### PR TITLE
verify whether instance is online before redirecting

### DIFF
--- a/src/assets/javascripts/helpers/common.js
+++ b/src/assets/javascripts/helpers/common.js
@@ -6,7 +6,34 @@ function getRandomInstance(instances) {
   return instances[~~(instances.length * Math.random())];
 }
 
+async function getRandomOnlineInstance(instances) {
+  const shuffledInstances = instances.sort((a,b) => 0.5-Math.random())
+
+  for(let ins of shuffledInstances) {
+    try {
+      const res = await fetch(ins, {
+        redirect: 'follow'
+      })
+      console.log(res)
+      if(res.status >= 200 && res.status < 300) {
+        // instance seems healthy!
+        return ins
+      } else {
+        console.warn(`Instance ${ins} seems offline (status code: ${res.status}). we try another one`)
+      }
+    } catch(err) {
+      console.warn(`Instance ${ins} seems offline. we try another one`)
+    }
+  }
+
+  // everything offline? -> unlikely
+  // rather respond with any entry instead of breaking the functionality
+  return shuffledInstances[0]
+}
+
+
 export default {
   filterInstances,
   getRandomInstance,
+  getRandomOnlineInstance
 };

--- a/src/assets/javascripts/remove-twitter-sw.js
+++ b/src/assets/javascripts/remove-twitter-sw.js
@@ -64,7 +64,7 @@ browser.storage.sync.get(
     "redirectBypassFlag",
     "exceptions",
   ],
-  (result) => {
+  async(result) => {
     redirectBypassFlag = result.redirectBypassFlag;
     browser.storage.sync.set({
       redirectBypassFlag: false,

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -234,7 +234,7 @@ function isFirefox() {
   return typeof InstallTrigger !== "undefined";
 }
 
-function redirectYouTube(url, initiator, type) {
+async function redirectYouTube(url, initiator, type) {
   if (disableInvidious || isException(url, initiator)) {
     return null;
   }
@@ -282,11 +282,11 @@ function redirectYouTube(url, initiator, type) {
   url.searchParams.append("autoplay", invidiousAutoplay ? 1 : 0);
 
   return `${
-    invidiousInstance || commonHelper.getRandomInstance(invidiousRandomPool)
+    invidiousInstance || await commonHelper.getRandomOnlineInstance(invidiousRandomPool)
   }${url.pathname.replace("/shorts", "")}${url.search}`;
 }
 
-function redirectTwitter(url, initiator) {
+async function redirectTwitter(url, initiator) {
   if (disableNitter || isException(url, initiator)) {
     return null;
   }
@@ -307,24 +307,24 @@ function redirectTwitter(url, initiator) {
   }
   if (url.host.split(".")[0] === "pbs") {
     return `${
-      nitterInstance || commonHelper.getRandomInstance(nitterRandomPool)
+      nitterInstance || await commonHelper.getRandomOnlineInstance(nitterRandomPool)
     }/pic/${encodeURIComponent(url.href)}`;
   } else if (url.host.split(".")[0] === "video") {
     return `${
-      nitterInstance || commonHelper.getRandomInstance(nitterRandomPool)
+      nitterInstance || await commonHelper.getRandomOnlineInstance(nitterRandomPool)
     }/gif/${encodeURIComponent(url.href)}`;
   } else if (url.pathname.split("/").includes("tweets")) {
     return `${
-      nitterInstance || commonHelper.getRandomInstance(nitterRandomPool)
+      nitterInstance || await commonHelper.getRandomOnlineInstance(nitterRandomPool)
     }${url.pathname.replace("/tweets", "")}${url.search}`;
   } else {
     return `${
-      nitterInstance || commonHelper.getRandomInstance(nitterRandomPool)
+      nitterInstance || await commonHelper.getRandomOnlineInstance(nitterRandomPool)
     }${url.pathname}${url.search}`;
   }
 }
 
-function redirectInstagram(url, initiator, type) {
+async function redirectInstagram(url, initiator, type) {
   if (disableBibliogram || isException(url, initiator)) {
     return null;
   }
@@ -346,12 +346,12 @@ function redirectInstagram(url, initiator, type) {
     instagramReservedPaths.includes(url.pathname.split("/")[1])
   ) {
     return `${
-      bibliogramInstance || commonHelper.getRandomInstance(bibliogramRandomPool)
+      bibliogramInstance || await commonHelper.getRandomOnlineInstance(bibliogramRandomPool)
     }${url.pathname}${url.search}`;
   } else {
     // Likely a user profile, redirect to '/u/...'
     return `${
-      bibliogramInstance || commonHelper.getRandomInstance(bibliogramRandomPool)
+      bibliogramInstance || await commonHelper.getRandomOnlineInstance(bibliogramRandomPool)
     }/u${url.pathname}${url.search}`;
   }
 }
@@ -513,7 +513,7 @@ function redirectGoogleTranslate(url, initiator) {
 }
 
 browser.webRequest.onBeforeRequest.addListener(
-  (details) => {
+  async (details) => {
     const url = new URL(details.url);
     let initiator;
     if (details.originUrl) {
@@ -524,15 +524,15 @@ browser.webRequest.onBeforeRequest.addListener(
     let redirect;
     if (youtubeDomains.includes(url.host)) {
       redirect = {
-        redirectUrl: redirectYouTube(url, initiator, details.type),
+        redirectUrl: await redirectYouTube(url, initiator, details.type),
       };
     } else if (twitterDomains.includes(url.host)) {
       redirect = {
-        redirectUrl: redirectTwitter(url, initiator),
+        redirectUrl: await redirectTwitter(url, initiator),
       };
     } else if (instagramDomains.includes(url.host)) {
       redirect = {
-        redirectUrl: redirectInstagram(url, initiator, details.type),
+        redirectUrl: await redirectInstagram(url, initiator, details.type),
       };
     } else if (url.href.match(googleMapsRegex)) {
       redirect = {


### PR DESCRIPTION
recently I got quite often redirected to an instance which is either showing an 50x error or is completely offline.

This PR checks the online state of an instance or, where necessary, picks the next one.

It also adds the usage of some ES2017 syntax (`async`/`await`) for the first time, but this is already available since Firefox 52[1], so it shouldn't be an issue.

----
[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#browser_compatibility