### PR TITLE
Enable SimplyTranslate by default

### DIFF
--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -573,16 +573,11 @@ browser.webRequest.onBeforeRequest.addListener(
 
 browser.runtime.onInstalled.addListener((details) => {
   browser.storage.sync.get(
-    ["disableSearchEngine", "disableSimplyTranslate"],
+    ["disableSearchEngine"],
     (result) => {
       if (result.disableSearchEngine === undefined) {
         browser.storage.sync.set({
           disableSearchEngine: true,
-        });
-      }
-      if (result.disableSimplyTranslate === undefined) {
-        browser.storage.sync.set({
-          disableSimplyTranslate: true,
         });
       }
     }

--- a/src/pages/options/options.html
+++ b/src/pages/options/options.html
@@ -169,7 +169,7 @@
           <tbody>
             <tr>
               <td>
-                <h1 data-localise="__MSG_disableSimplyTranslate__" class="new-badge" data-new-badge>SimplyTranslate Redirects</h1>
+                <h1 data-localise="__MSG_disableSimplyTranslate__">SimplyTranslate Redirects</h1>
               </td>
               <td>
                 <input

--- a/src/pages/popup/popup.html
+++ b/src/pages/popup/popup.html
@@ -174,7 +174,7 @@
                 aria-hidden="true"
                 id="disable-simplyTranslate"
                 type="checkbox"
-		checked
+                checked
               />&nbsp;
               <label
                 for="disable-simplyTranslate"

--- a/src/pages/popup/popup.html
+++ b/src/pages/popup/popup.html
@@ -165,11 +165,7 @@
         <tbody>
           <tr>
             <td>
-              <h1
-                data-localise="__MSG_disableSimplyTranslate__"
-                class="new-badge"
-                data-new-badge
-              >
+              <h1 data-localise="__MSG_disableSimplyTranslate__">
                 SimplyTranslate Redirects
               </h1>
             </td>

--- a/src/pages/popup/popup.html
+++ b/src/pages/popup/popup.html
@@ -174,6 +174,7 @@
                 aria-hidden="true"
                 id="disable-simplyTranslate"
                 type="checkbox"
+		checked
               />&nbsp;
               <label
                 for="disable-simplyTranslate"


### PR DESCRIPTION
I personally think that the redirection works pretty well, but feel free to delay/not merge this PR at all if so you wish.

Also, a minor note: I think SimplyTranslate should be moved above "Search Engines", which I find a more logical order. Thoughts?