### PR TITLE
Add redirect for Norwegian Google Translate

### DIFF
--- a/src/assets/javascripts/helpers/google-translate.js
+++ b/src/assets/javascripts/helpers/google-translate.js
@@ -1,4 +1,4 @@
-const targets = ["translate.google.com"];
+const targets = ["translate.google.com", "translate.google.no"];
 
 const redirects = ["https://translate.metalune.xyz"];
 


### PR DESCRIPTION
Not sure if there is a better and easier way to add more versions of Google Translate. But I just appended the Norwegian-version to the array.

Privacy Redirect is not useful for us in other countries than the us it seems, since it only redirects on the `.com` version of the site and not any others.

Feel free to explain how I can improve the PR or feel free to expand upon it 😄 