### PR TITLE
Add Wikiless support

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -35,6 +35,10 @@
     "message": "SimplyTranslate Instance",
     "description": "Label for SimplyTranslate instance field option (options)."
   },
+  "wikipediaInstance": {
+    "message": "Wikipedia Instance",
+    "description": "Label for Wikipedia instance field option (options)."
+  },
   "disableNitter": {
     "message": "Nitter Redirects",
     "description": "Label for enable/disable Nitter redirects option (options & pop-up)."
@@ -62,6 +66,10 @@
   "disableSimplyTranslate": {
     "message": "SimplyTranslate Redirects",
     "description": "Label for enable/disable SimplyTranslate redirects option (options & pop-up)."
+  },
+  "disableWikipedia": {
+    "message": "Wikipedia Redirects",
+    "description": "Label for enable/disable Wikipedia redirects option (options & pop-up)."
   },
   "alwaysProxy": {
     "message": "Always proxy videos through Invidious",

--- a/src/assets/javascripts/helpers/wikipedia.js
+++ b/src/assets/javascripts/helpers/wikipedia.js
@@ -1,0 +1,8 @@
+const targets = /wikipedia.org/;
+
+const redirects = ["https://wikiless.org"];
+
+export default {
+  targets,
+  redirects,
+};

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -35,7 +35,7 @@ const simplyTranslateInstances = googleTranslateHelper.redirects;
 const simplyTranslateDefault = simplyTranslateInstances[0];
 const googleTranslateDomains = googleTranslateHelper.targets;
 const wikipediaInstances = wikipediaHelper.redirects;
-const wikipediaDefault = simplyTranslateInstances[0];
+const wikipediaDefault = wikipediaInstances[0];
 const wikipediaRegex = wikipediaHelper.targets;
 
 let disableNitter;

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -601,7 +601,7 @@ browser.webRequest.onBeforeRequest.addListener(
       redirect = {
         redirectUrl: redirectGoogleTranslate(url, initiator),
       };
-    } else if (url.href.match(wikipediaRegex)) {
+    } else if (url.host.match(wikipediaRegex)) {
       redirect = {
         redirectUrl: redirectWikipedia(url, initiator),
       };

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -543,7 +543,6 @@ function redirectGoogleTranslate(url, initiator) {
 }
 
 function redirectWikipedia(url, initiator) {
-    console.log(url);
   if (disableWikipedia || isException(url, initiator)) {
     return null;
   }
@@ -556,7 +555,6 @@ function redirectWikipedia(url, initiator) {
 	GETArguments.push([args[0],args[1]]);
       }
     }
-    
   let link = `${wikipediaInstance}${url.pathname}`;
   let urlSplit = url.host.split('.');
   if (urlSplit[0] != "wikipedia" && urlSplit[0] != "www") {

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -543,24 +543,41 @@ function redirectGoogleTranslate(url, initiator) {
 }
 
 function redirectWikipedia(url, initiator) {
+    console.log(url);
   if (disableWikipedia || isException(url, initiator)) {
     return null;
   }
+  let GETArguments = [];
+    if (url.search.length > 0) {
+      let search = url.search.substring(1); //get rid of '?'
+      let argstrings = search.split('&');
+      for (let i = 0; i < argstrings.length;i++) {
+	let args = argstrings[i].split('=');
+	GETArguments.push([args[0],args[1]]);
+      }
+    }
+    
   let link = `${wikipediaInstance}${url.pathname}`;
   let urlSplit = url.host.split('.');
   if (urlSplit[0] != "wikipedia" && urlSplit[0] != "www") {
     if (urlSplit[0] == 'm')
-      link += "?mobileaction=toggle_view_mobile";
+	GETArguments.push(["mobileaction","toggle_view_mobile"]);
     else
-      link += `?lang=${urlSplit[0]}`;
+      	GETArguments.push(["lang",urlSplit[0]]);
     if (urlSplit[1] == 'm')
-      link += "&mobileaction=toggle_view_mobile";
+      	GETArguments.push(["mobileaction","toggle_view_mobile"]);
       //wikiless doesn't have mobile view support yet
   }
+  for (let i = 0; i < GETArguments.length; i++) {
+    link += (i == 0 ? '?' : '&') + GETArguments[i][0] +
+      '=' + GETArguments[i][1];
+  }
   if (urlSplit[urlSplit.length - 1] == "org" &&
-      urlSplit[urlSplit.length - 2] == "wikipedia")
+      urlSplit[urlSplit.length - 2] == "wikipedia") 
     //just in case someone wanted to visit wikipedia.org.foo.bar.net
-    return link;
+    return link; 
+  else
+    return null;
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -163,7 +163,6 @@ browser.storage.onChanged.addListener((changes) => {
     simplyTranslateInstance =
       changes.simplyTranslateInstance.newValue || simplyTranslateDefault;
   }
-
   if ("wikipediaInstance" in changes) {
     wikipediaInstance =
 	changes.wikipediaInstance.newValue || wikipediaDefault;
@@ -554,7 +553,6 @@ function redirectWikipedia(url, initiator) {
       link += "?mobileaction=toggle_view_mobile";
     else
       link += `?lang=${urlSplit[0]}`;
-      
     if (urlSplit[1] == 'm')
       link += "&mobileaction=toggle_view_mobile";
       //wikiless doesn't have mobile view support yet
@@ -569,14 +567,12 @@ browser.webRequest.onBeforeRequest.addListener(
   (details) => {
     const url = new URL(details.url);
     let initiator;
-
     if (details.originUrl) {
       initiator = new URL(details.originUrl);
     } else if (details.initiator) {
       initiator = new URL(details.initiator);
     }
     let redirect;
-    
     if (youtubeDomains.includes(url.host)) {
       redirect = {
         redirectUrl: redirectYouTube(url, initiator, details.type),

--- a/src/pages/options/options.html
+++ b/src/pages/options/options.html
@@ -268,7 +268,7 @@
         </div>
       </section>
       <section class="settings-block">
-       <h1 data-localise="__MSG_simplyTranslateInstance__">SimplyTranslate Instance</h1>
+        <h1 data-localise="__MSG_simplyTranslateInstance__">SimplyTranslate Instance</h1>
         <div class="autocomplete">
           <input
             id="simply-translate-instance"

--- a/src/pages/options/options.html
+++ b/src/pages/options/options.html
@@ -184,6 +184,25 @@
         </table>
       </section>
       <section class="settings-block">
+        <table class="option" aria-label="Toggle Wikipedia redirects">
+          <tbody>
+            <tr>
+              <td>
+                <h1 data-localise="__MSG_disableWikipedia__">Wikipedia Redirects</h1>
+              </td>
+              <td>
+                <input
+                  aria-hidden="true"
+                  id="disable-wikipedia"
+                  type="checkbox"
+                />&nbsp;
+                <label for="disable-wikipedia" class="checkbox-label"></label>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="settings-block">
         <h1 data-localise="__MSG_nitterInstance__">Nitter Instance</h1>
         <div class="autocomplete">
           <input
@@ -248,13 +267,23 @@
           />
         </div>
       </section>
-      <section class="settings-block">
+       <section class="settings-block">
         <h1 data-localise="__MSG_simplyTranslateInstance__">SimplyTranslate Instance</h1>
         <div class="autocomplete">
           <input
             id="simply-translate-instance"
             type="url"
             placeholder="https://translate.metalune.xyz"
+          />
+        </div>
+      </section>
+      <section class="settings-block">
+        <h1 data-localise="__MSG_wikipediaInstance__">Wikipedia Instance</h1>
+        <div class="autocomplete">
+          <input
+            id="wikipedia-instance"
+            type="url"
+            placeholder="https://wikiless.org"
           />
         </div>
       </section>

--- a/src/pages/options/options.html
+++ b/src/pages/options/options.html
@@ -267,8 +267,8 @@
           />
         </div>
       </section>
-       <section class="settings-block">
-        <h1 data-localise="__MSG_simplyTranslateInstance__">SimplyTranslate Instance</h1>
+      <section class="settings-block">
+       <h1 data-localise="__MSG_simplyTranslateInstance__">SimplyTranslate Instance</h1>
         <div class="autocomplete">
           <input
             id="simply-translate-instance"

--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -8,6 +8,7 @@ import mapsHelper from "../../assets/javascripts/helpers/google-maps.js";
 import redditHelper from "../../assets/javascripts/helpers/reddit.js";
 import searchHelper from "../../assets/javascripts/helpers/google-search.js";
 import googleTranslateHelper from "../../assets/javascripts/helpers/google-translate.js";
+import wikipediaHelper from "../../assets/javascripts/helpers/wikipedia.js";
 
 const nitterInstances = twitterHelper.redirects;
 const invidiousInstances = youtubeHelper.redirects;
@@ -16,6 +17,7 @@ const osmInstances = mapsHelper.redirects;
 const redditInstances = redditHelper.redirects;
 const searchEngineInstances = searchHelper.redirects;
 const simplyTranslateInstances = googleTranslateHelper.redirects;
+const wikipediaInstances = wikipediaHelper.redirects;
 const autocompletes = [
   { id: "nitter-instance", instances: nitterInstances },
   { id: "invidious-instance", instances: invidiousInstances },
@@ -27,6 +29,7 @@ const autocompletes = [
     instances: searchEngineInstances.map((instance) => instance.link),
   },
   { id: "simply-translate-instance", instances: simplyTranslateInstances },
+  { id: "wikipedia-instance", instances: wikipediaInstances },
 ];
 const domparser = new DOMParser();
 
@@ -39,6 +42,7 @@ let searchEngineInstance = document.getElementById("search-engine-instance");
 let simplyTranslateInstance = document.getElementById(
   "simply-translate-instance"
 );
+let wikipediaInstance = document.getElementById("wikipedia-instance");
 let disableNitter = document.getElementById("disable-nitter");
 let disableInvidious = document.getElementById("disable-invidious");
 let disableBibliogram = document.getElementById("disable-bibliogram");
@@ -48,6 +52,7 @@ let disableSearchEngine = document.getElementById("disable-search-engine");
 let disableSimplyTranslate = document.getElementById(
   "disable-simply-translate"
 );
+let disableWikipedia = document.getElementById("disable-wikipedia");
 let alwaysProxy = document.getElementById("always-proxy");
 let onlyEmbeddedVideo = document.getElementById("only-embed");
 let videoQuality = document.getElementById("video-quality");
@@ -100,6 +105,7 @@ browser.storage.sync.get(
     "redditInstance",
     "searchEngineInstance",
     "simplyTranslateInstance",
+    "wikipediaInstance",
     "disableNitter",
     "disableInvidious",
     "disableBibliogram",
@@ -107,6 +113,7 @@ browser.storage.sync.get(
     "disableReddit",
     "disableSearchEngine",
     "disableSimplyTranslate",
+    "disableWikipedia",
     "alwaysProxy",
     "onlyEmbeddedVideo",
     "videoQuality",
@@ -135,6 +142,7 @@ browser.storage.sync.get(
     searchEngineInstance.value =
       (result.searchEngineInstance && result.searchEngineInstance.link) || "";
     simplyTranslateInstance.value = result.simplyTranslateInstance || "";
+    wikipediaInstance.value = result.wikipediaInstance || "";
     disableNitter.checked = !result.disableNitter;
     disableInvidious.checked = !result.disableInvidious;
     disableBibliogram.checked = !result.disableBibliogram;
@@ -142,6 +150,7 @@ browser.storage.sync.get(
     disableReddit.checked = !result.disableReddit;
     disableSearchEngine.checked = !result.disableSearchEngine;
     disableSimplyTranslate.checked = !result.disableSimplyTranslate;
+    disableWikipedia.checked = !result.disableWikipedia;
     alwaysProxy.checked = result.alwaysProxy;
     onlyEmbeddedVideo.checked = result.onlyEmbeddedVideo;
     videoQuality.value = result.videoQuality || "";
@@ -328,6 +337,18 @@ simplyTranslateInstance.addEventListener(
   simplyTranslateInstanceChange
 );
 
+const wikipediaInstanceChange = debounce(() => {
+  if (wikipediaInstance.checkValidity()) {
+    browser.storage.sync.set({
+      wikipediaInstance: parseURL(wikipediaInstance.value),
+    });
+  }
+}, 500);
+wikipediaInstance.addEventListener(
+  "input",
+  wikipediaInstanceChange
+);
+
 disableNitter.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableNitter: !event.target.checked });
 });
@@ -354,6 +375,10 @@ disableSearchEngine.addEventListener("change", (event) => {
 
 disableSimplyTranslate.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableSimplyTranslate: !event.target.checked });
+});
+
+disableWikipedia.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableWikipedia: !event.target.checked });
 });
 
 alwaysProxy.addEventListener("change", (event) => {

--- a/src/pages/popup/popup.html
+++ b/src/pages/popup/popup.html
@@ -185,6 +185,31 @@
       </table>
     </section>
 
+    <section class="settings-block">
+      <table class="option" aria-label="Toggle Wikiepdia redirects">
+        <tbody>
+          <tr>
+            <td>
+              <h1 data-localise="__MSG_disableWikipedia__">
+                Wikipedia Redirects
+              </h1>
+            </td>
+            <td>
+              <input
+                aria-hidden="true"
+                id="disable-wikipedia"
+                type="checkbox"
+              />&nbsp;
+              <label
+                for="disable-wikipedia"
+                class="checkbox-label"
+              ></label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
     <section class="settings-block"></section>
 
     <footer>

--- a/src/pages/popup/popup.js
+++ b/src/pages/popup/popup.js
@@ -7,6 +7,7 @@ let disableOsm = document.querySelector("#disable-osm");
 let disableReddit = document.querySelector("#disable-reddit");
 let disableSearchEngine = document.querySelector("#disable-searchEngine");
 let disableSimplyTranslate = document.querySelector("#disable-simplyTranslate");
+let disableWikipedia = document.querySelector("#disable-wikipedia");
 let version = document.querySelector("#version");
 
 window.browser = window.browser || window.chrome;
@@ -20,6 +21,7 @@ browser.storage.sync.get(
     "disableReddit",
     "disableSearchEngine",
     "disableSimplyTranslate",
+    "disableWikipedia",
     "theme",
   ],
   (result) => {
@@ -31,6 +33,7 @@ browser.storage.sync.get(
     disableReddit.checked = !result.disableReddit;
     disableSearchEngine.checked = !result.disableSearchEngine;
     disableSimplyTranslate.checked = !result.disableSimplyTranslate;
+    disableWikipedia.checked = !result.disableWikipedia;
   }
 );
 
@@ -62,6 +65,10 @@ disableSearchEngine.addEventListener("change", (event) => {
 
 disableSimplyTranslate.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableSimplyTranslate: !event.target.checked });
+});
+
+disableWikipedia.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableWikipedia: !event.target.checked });
 });
 
 document.querySelector("#more-options").addEventListener("click", () => {


### PR DESCRIPTION
[Wikiless](https://codeberg.org/orenom/wikiless) is a privacy focused front-end for Wikipedia. I think it would be good if it was included with the other sites in this extension. The code in the pull request currently has an option in the extensions menu to enable/disable Wikipedia redirects. When it's enabled, `redirectWikipedia` function will catch any request with a host matching `/wikipedia.org/` regex. after that it will make sure it belongs to Wikipedia, and redirect to wikiless instance with specified language and mobile view if enabled.