### PR TITLE
removing invidious.fdn.fr

### DIFF
--- a/src/assets/javascripts/helpers/youtube.js
+++ b/src/assets/javascripts/helpers/youtube.js
@@ -26,7 +26,6 @@ const redirects = [
   "https://yewtu.be",
   "https://invidious.tube",
   "https://invidious.silkky.cloud",
-  "https://invidious.fdn.fr",
   "https://invidious.himiko.cloud",
   "https://inv.skyn3t.in",
   "https://tube.incognet.io",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -50,7 +50,6 @@
         "*://yewtu.be/*",
         "*://invidious.tube/*",
         "*://invidious.silkky.cloud/*",
-        "*://invidious.fdn.fr/*",
         "*://invidious.himiko.cloud/*",
         "*://inv.skyn3t.in/*",
         "*://tube.incognet.io/*",


### PR DESCRIPTION
This PR remove `invidious.fdn.fr` from privacy redirect.
The instance is broken for months, we even removed it 3 months ago from the public instances list because it was unmaintained: https://github.com/iv-org/documentation/commit/25d855b22d8f9eebecd3b6ca7c49b4eb157b939c

We still receive issues on our invidious repo even though the instance got removed from the public list (example: https://github.com/iv-org/invidious/issues/2253) and that's why we think that people are still using it due to privacy redirect still having it in its list.