### PR TITLE
Add rimgu redirect support for imgur

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## About
 
-A web extension that redirects _Twitter, YouTube, Instagram, Google Maps, Reddit, Google Search, & Google Translate_ requests to privacy friendly alternatives - [Nitter](https://github.com/zedeus/nitter), [Invidious](https://github.com/iv-org/invidious), [FreeTube](https://github.com/FreeTubeApp/FreeTube), [Bibliogram](https://sr.ht/~cadence/bibliogram/), [OpenStreetMap](https://www.openstreetmap.org/), [SimplyTranslate](https://git.sr.ht/~metalune/simplytranslate_web) & Private Search Engines like [DuckDuckGo](https://duckduckgo.com) and [Startpage](https://startpage.com).
+A web extension that redirects _Twitter, YouTube, Instagram, Google Maps, Reddit, Google Search, & Google Translate_ requests to privacy friendly alternative frontends for those sites - [Nitter](https://github.com/zedeus/nitter), [Invidious](https://github.com/iv-org/invidious), [FreeTube](https://github.com/FreeTubeApp/FreeTube), [Bibliogram](https://sr.ht/~cadence/bibliogram/), [OpenStreetMap](https://www.openstreetmap.org/), [SimplyTranslate](https://git.sr.ht/~metalune/simplytranslate_web) & Private Search Engines like [DuckDuckGo](https://duckduckgo.com) and [Startpage](https://startpage.com).
 
 It's possible to toggle all redirects on and off. The extension will default to using random instances if none are selected. If these instances are not working, you can try and set a custom instance from the list below.
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -19,6 +19,10 @@
     "message": "Bibliogram Instance",
     "description": "Label for Bibliogram instance field option (options)."
   },
+  "rimguInstance": {
+    "message": "Rimgu Instance",
+    "description": "Label for Rimgu instance field option (options)."
+  },
   "osmInstance": {
     "message": "OpenStreetMap Instance",
     "description": "Label for OSM instance field option (options)."
@@ -50,6 +54,10 @@
   "disableBibliogram": {
     "message": "Bibliogram Redirects",
     "description": "Label for enable/disable Bibliogram redirects option (options & pop-up)."
+  },
+  "disableRimgu": {
+    "message": "Rimgu Redirects",
+    "description": "Label for enable/disable Rimgu redirects option (options & pop-up)."
   },
   "disableOsm": {
     "message": "OpenStreetMap Redirects",
@@ -154,6 +162,10 @@
   "bibliogramRandomPool": {
     "message": "Bibliogram random instance pool (comma-separated)",
     "description": "Label for 'Bibliogram random instance pool (comma-separated)' option (options)."
+  },
+  "rimguRandomPool": {
+    "message": "Rimgu random instance pool (comma-separated)",
+    "description": "Label for 'Rimgu random instance pool (comma-separated)' option (options)."
   },
   "randomInstancePlaceholder": {
     "message": "Random instance (none selected)",

--- a/src/_locales/fr/store.md
+++ b/src/_locales/fr/store.md
@@ -9,7 +9,7 @@ Redirige les requêtes les demandes Twitter, YouTube, Instagram et Google Maps v
 ## Description:
 
 ```
-Redirige les requètes pour Twitter, YouTube, Instagram et Google Maps vers des alternatives respectueuses de la confidentialité - <a href="https://nitter.net/">Nitter</a>, <a href="https://invidio.us/">Invidious</a>, <a href="https://bibliogram.art/">Bibliogram</a>, & <a href="https://www.openstreetmap.org">OpenStreetMap</a>.
+Redirige les requêtes pour Twitter, YouTube, Instagram et Google Maps vers des alternatives respectueuses de la confidentialité - <a href="https://nitter.net/">Nitter</a>, <a href="https://invidio.us/">Invidious</a>, <a href="https://bibliogram.art/">Bibliogram</a>, & <a href="https://www.openstreetmap.org">OpenStreetMap</a>.
 
 Permet de définir des instances personnalisées et d'activer ou désactiver toutes les redirections.
 

--- a/src/assets/javascripts/helpers/imgur.js
+++ b/src/assets/javascripts/helpers/imgur.js
@@ -1,0 +1,9 @@
+const targets = /^([A-z.]+\.)?imgur.com/
+
+const redirects = [
+];
+
+export default {
+  targets,
+  redirects,
+};

--- a/src/assets/javascripts/helpers/reddit.js
+++ b/src/assets/javascripts/helpers/reddit.js
@@ -5,6 +5,7 @@ const targets = [
   "amp.reddit.com",
   "i.redd.it",
   "redd.it",
+  "old.reddit.com",
 ];
 const redirects = [
   // libreddit: privacy w/ modern UI
@@ -16,14 +17,11 @@ const redirects = [
   "https://libreddit.silkky.cloud",
   "https://libreddit.himiko.cloud",
   "https://reddit.artemislena.eu",
-  "https://reddit.git-bruh.duckdns.org",
   // teddit: privacy w/ old UI
   "https://teddit.net",
   "https://teddit.ggc-project.de",
   "https://teddit.kavin.rocks",
-  "https://old.reddit.com", // desktop
-  "https://i.reddit.com", // mobile
-  "https://snew.notabug.io", // anti-censorship
+  "https://snew.notabug.io",
 ];
 const bypassPaths = /\/(gallery\/poll\/rpan\/settings\/topics)/;
 

--- a/src/assets/javascripts/helpers/twitter.js
+++ b/src/assets/javascripts/helpers/twitter.js
@@ -9,6 +9,7 @@ const targets = [
   "mobile.twitter.com",
   "pbs.twimg.com",
   "video.twimg.com",
+  "platform.twitter.com",
 ];
 /*
     Please remember to also update the 

--- a/src/assets/javascripts/helpers/youtube.js
+++ b/src/assets/javascripts/helpers/youtube.js
@@ -35,7 +35,6 @@ const redirects = [
   "https://dev.viewtube.io",
   "https://invidious.048596.xyz",
   "http://fz253lmuao3strwbfbmx46yu7acac2jz27iwtorgmbqlkurlclmancad.onion",
-  "http://qklhadlycap4cnod.onion",
   "http://c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion",
   "http://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion",
 ];

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -59,7 +59,6 @@
         "*://dev.viewtube.io/*",
         "*://invidious.048596.xyz/*",
         "*://fz253lmuao3strwbfbmx46yu7acac2jz27iwtorgmbqlkurlclmancad.onion/*",
-        "*://qklhadlycap4cnod.onion/*",
         "*://c7hqkpkpemu6e7emz5b4vyz7idjgdvgaaa3dyimmeojqbgpea3xqjoid.onion/*",
         "*://w6ijuptxiku4xpnnaetxvnkc5vqcdu7mgns2u77qefoixi63vbvnpnqd.onion/*"
       ],

--- a/src/pages/options/options.html
+++ b/src/pages/options/options.html
@@ -99,6 +99,28 @@
         </table>
       </section>
       <section class="settings-block">
+        <table class="option" aria-label="Toggle Rimgu redirects">
+          <tbody>
+            <tr>
+              <td>
+                <h1 data-localise="__MSG_disableRimgu__">
+                  Rimgu Redirects
+                </h1>
+              </td>
+              <td>
+                <input
+                  aria-hidden="true"
+                  id="disable-rimgu"
+                  type="checkbox"
+                  checked
+                />&nbsp;
+                <label for="disable-rimgu" class="checkbox-label"> </label>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="settings-block">
         <table class="option" aria-label="Toggle OpenStreetMap redirects">
           <tbody>
             <tr>
@@ -230,6 +252,17 @@
         <div class="autocomplete">
           <input
             id="bibliogram-instance"
+            type="url"
+            data-localise-placeholder="__MSG_randomInstancePlaceholder__"
+            placeholder="Random instance (none selected)"
+          />
+        </div>
+      </section>
+      <section class="settings-block">
+        <h1 data-localise="__MSG_rimguInstance__">Rimgu Instance</h1>
+        <div class="autocomplete">
+          <input
+            id="rimgu-instance"
             type="url"
             data-localise-placeholder="__MSG_randomInstancePlaceholder__"
             placeholder="Random instance (none selected)"
@@ -554,6 +587,22 @@
           <input
             id="bibliogram-random-pool"
             name="bibliogram-random-pool"
+            type="text"
+          />
+        </section>
+        <hr>
+      </div>
+      <button type="button" class="collapsible">
+        Rimgu
+      </button>
+      <div class="collapsible-content">
+        <section class="settings-block">
+          <h1 data-localise="__MSG_rimguRandomPool__">
+            Rimgu random instance pool (comma-separated)
+          </h1>
+          <input
+            id="rimgu-random-pool"
+            name="rimgu-random-pool"
             type="text"
           />
         </section>

--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -4,6 +4,7 @@ import commonHelper from "../../assets/javascripts/helpers/common.js";
 import twitterHelper from "../../assets/javascripts/helpers/twitter.js";
 import youtubeHelper from "../../assets/javascripts/helpers/youtube.js";
 import instagramHelper from "../../assets/javascripts/helpers/instagram.js";
+import imgurHelper from "../../assets/javascripts/helpers/imgur.js";
 import mapsHelper from "../../assets/javascripts/helpers/google-maps.js";
 import redditHelper from "../../assets/javascripts/helpers/reddit.js";
 import searchHelper from "../../assets/javascripts/helpers/google-search.js";
@@ -13,6 +14,7 @@ import wikipediaHelper from "../../assets/javascripts/helpers/wikipedia.js";
 const nitterInstances = twitterHelper.redirects;
 const invidiousInstances = youtubeHelper.redirects;
 const bibliogramInstances = instagramHelper.redirects;
+const rimguInstances = imgurHelper.redirects;
 const osmInstances = mapsHelper.redirects;
 const redditInstances = redditHelper.redirects;
 const searchEngineInstances = searchHelper.redirects;
@@ -22,6 +24,7 @@ const autocompletes = [
   { id: "nitter-instance", instances: nitterInstances },
   { id: "invidious-instance", instances: invidiousInstances },
   { id: "bibliogram-instance", instances: bibliogramInstances },
+  { id: "rimgu-instance", instances: rimguInstances },
   { id: "osm-instance", instances: osmInstances },
   { id: "reddit-instance", instances: redditInstances },
   {
@@ -36,6 +39,7 @@ const domparser = new DOMParser();
 let nitterInstance = document.getElementById("nitter-instance");
 let invidiousInstance = document.getElementById("invidious-instance");
 let bibliogramInstance = document.getElementById("bibliogram-instance");
+let rimguInstance = document.getElementById("rimgu-instance");
 let osmInstance = document.getElementById("osm-instance");
 let redditInstance = document.getElementById("reddit-instance");
 let searchEngineInstance = document.getElementById("search-engine-instance");
@@ -46,6 +50,7 @@ let wikipediaInstance = document.getElementById("wikipedia-instance");
 let disableNitter = document.getElementById("disable-nitter");
 let disableInvidious = document.getElementById("disable-invidious");
 let disableBibliogram = document.getElementById("disable-bibliogram");
+let disableRimgu = document.getElementById("disable-rimgu");
 let disableOsm = document.getElementById("disable-osm");
 let disableReddit = document.getElementById("disable-reddit");
 let disableSearchEngine = document.getElementById("disable-search-engine");
@@ -68,6 +73,7 @@ let useFreeTube = document.getElementById("use-freetube");
 let nitterRandomPool = document.getElementById("nitter-random-pool");
 let invidiousRandomPool = document.getElementById("invidious-random-pool");
 let bibliogramRandomPool = document.getElementById("bibliogram-random-pool");
+let rimguRandomPool = document.getElementById("rimgu-random-pool");
 let exceptions;
 
 window.browser = window.browser || window.chrome;
@@ -101,6 +107,7 @@ browser.storage.sync.get(
     "nitterInstance",
     "invidiousInstance",
     "bibliogramInstance",
+    "rimguInstance",
     "osmInstance",
     "redditInstance",
     "searchEngineInstance",
@@ -109,6 +116,7 @@ browser.storage.sync.get(
     "disableNitter",
     "disableInvidious",
     "disableBibliogram",
+    "disableRimgu",
     "disableOsm",
     "disableReddit",
     "disableSearchEngine",
@@ -130,6 +138,7 @@ browser.storage.sync.get(
     "nitterRandomPool",
     "invidiousRandomPool",
     "bibliogramRandomPool",
+    "rimguRandomPool",
   ],
   (result) => {
     theme.value = result.theme || "";
@@ -137,6 +146,7 @@ browser.storage.sync.get(
     nitterInstance.value = result.nitterInstance || "";
     invidiousInstance.value = result.invidiousInstance || "";
     bibliogramInstance.value = result.bibliogramInstance || "";
+    rimguInstance.value = result.rimguInstance || "";
     osmInstance.value = result.osmInstance || "";
     redditInstance.value = result.redditInstance || "";
     searchEngineInstance.value =
@@ -146,6 +156,7 @@ browser.storage.sync.get(
     disableNitter.checked = !result.disableNitter;
     disableInvidious.checked = !result.disableInvidious;
     disableBibliogram.checked = !result.disableBibliogram;
+    disableRimgu.checked = !result.disableRimgu;
     disableOsm.checked = !result.disableOsm;
     disableReddit.checked = !result.disableReddit;
     disableSearchEngine.checked = !result.disableSearchEngine;
@@ -175,6 +186,9 @@ browser.storage.sync.get(
     bibliogramRandomPool.value =
       result.bibliogramRandomPool ||
       commonHelper.filterInstances(bibliogramInstances);
+    rimguRandomPool.value =
+      result.rimguRandomPool ||
+      commonHelper.filterInstances(rimguInstances);
   }
 );
 
@@ -293,6 +307,15 @@ const bibliogramInstanceChange = debounce(() => {
 }, 500);
 bibliogramInstance.addEventListener("input", bibliogramInstanceChange);
 
+const rimguInstanceChange = debounce(() => {
+  if (rimguInstance.checkValidity()) {
+    browser.storage.sync.set({
+      rimguInstance: parseURL(rimguInstance.value),
+    });
+  }
+}, 500);
+rimguInstance.addEventListener("input", rimguInstanceChange);
+
 const osmInstanceChange = debounce(() => {
   if (osmInstance.checkValidity()) {
     browser.storage.sync.set({
@@ -359,6 +382,10 @@ disableInvidious.addEventListener("change", (event) => {
 
 disableBibliogram.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableBibliogram: !event.target.checked });
+});
+
+disableRimgu.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableRimgu: !event.target.checked });
 });
 
 disableOsm.addEventListener("change", (event) => {
@@ -453,6 +480,13 @@ const bibliogramRandomPoolChange = debounce(() => {
   });
 }, 500);
 bibliogramRandomPool.addEventListener("input", bibliogramRandomPoolChange);
+
+const rimguRandomPoolChange = debounce(() => {
+  browser.storage.sync.set({
+    rimguRandomPool: rimguRandomPool.value,
+  });
+}, 500);
+rimguRandomPool.addEventListener("input", rimguRandomPoolChange);
 
 theme.addEventListener("change", (event) => {
   const value = event.target.options[theme.selectedIndex].value;

--- a/src/pages/popup/popup.html
+++ b/src/pages/popup/popup.html
@@ -94,6 +94,29 @@
     </section>
 
     <section class="settings-block">
+      <table class="option" aria-label="Toggle Rimgu redirects">
+        <tbody>
+          <tr>
+            <td>
+              <h1 data-localise="__MSG_disableRimgu__">
+                Rimgu Redirects
+              </h1>
+            </td>
+            <td>
+              <input
+                aria-hidden="true"
+                id="disable-rimgu"
+                type="checkbox"
+                checked
+              />&nbsp;
+              <label for="disable-rimgu" class="checkbox-label"> </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="settings-block">
       <table class="option" aria-label="Toggle OpenStreetMap redirects">
         <tbody>
           <tr>
@@ -186,7 +209,7 @@
     </section>
 
     <section class="settings-block">
-      <table class="option" aria-label="Toggle Wikiepdia redirects">
+      <table class="option" aria-label="Toggle Wikipedia redirects">
         <tbody>
           <tr>
             <td>

--- a/src/pages/popup/popup.js
+++ b/src/pages/popup/popup.js
@@ -3,6 +3,7 @@
 let disableNitter = document.querySelector("#disable-nitter");
 let disableInvidious = document.querySelector("#disable-invidious");
 let disableBibliogram = document.querySelector("#disable-bibliogram");
+let disableRimgu = document.querySelector("#disable-rimgu");
 let disableOsm = document.querySelector("#disable-osm");
 let disableReddit = document.querySelector("#disable-reddit");
 let disableSearchEngine = document.querySelector("#disable-searchEngine");
@@ -17,6 +18,7 @@ browser.storage.sync.get(
     "disableNitter",
     "disableInvidious",
     "disableBibliogram",
+    "disableRimgu",
     "disableOsm",
     "disableReddit",
     "disableSearchEngine",
@@ -29,6 +31,7 @@ browser.storage.sync.get(
     disableNitter.checked = !result.disableNitter;
     disableInvidious.checked = !result.disableInvidious;
     disableBibliogram.checked = !result.disableBibliogram;
+    disableRimgu.checked = !result.disableRimgu;
     disableOsm.checked = !result.disableOsm;
     disableReddit.checked = !result.disableReddit;
     disableSearchEngine.checked = !result.disableSearchEngine;
@@ -49,6 +52,10 @@ disableInvidious.addEventListener("change", (event) => {
 
 disableBibliogram.addEventListener("change", (event) => {
   browser.storage.sync.set({ disableBibliogram: !event.target.checked });
+});
+
+disableRimgu.addEventListener("change", (event) => {
+  browser.storage.sync.set({ disableRimgu: !event.target.checked });
 });
 
 disableOsm.addEventListener("change", (event) => {


### PR DESCRIPTION
imgur.com is particularly overwhelming with tracking scripts and 3rd-party requests. A new project that fills the gap for embeddeds as well as web URLs is https://codeberg.org/3np/rimgu.

This adds imgur/rimgu support to Privacy Redirect.