### PR TITLE
Add missing Reddit source URLs

### DIFF
--- a/src/assets/javascripts/helpers/reddit.js
+++ b/src/assets/javascripts/helpers/reddit.js
@@ -5,6 +5,9 @@ const targets = [
   "amp.reddit.com",
   "i.redd.it",
   "redd.it",
+  "reddit.com",
+  "old.reddit.com",
+  "i.reddit.com",
 ];
 const redirects = [
   // libreddit: privacy w/ modern UI


### PR DESCRIPTION
Fixes: https://github.com/SimonBrazell/privacy-redirect/issues/271

New source URLs that will be redirected:
- reddit.com
- old.reddit.com
- i.reddit.com
