### PR TITLE
Removes old.reddit.com/i.reddit.com/dead links. Adds old.reddit.com to redirection targets.

### DIFF
--- a/src/assets/javascripts/helpers/reddit.js
+++ b/src/assets/javascripts/helpers/reddit.js
@@ -5,6 +5,7 @@ const targets = [
   "amp.reddit.com",
   "i.redd.it",
   "redd.it",
+  "old.reddit.com",
 ];
 const redirects = [
   // libreddit: privacy w/ modern UI
@@ -16,14 +17,11 @@ const redirects = [
   "https://libreddit.silkky.cloud",
   "https://libreddit.himiko.cloud",
   "https://reddit.artemislena.eu",
-  "https://reddit.git-bruh.duckdns.org",
   // teddit: privacy w/ old UI
   "https://teddit.net",
   "https://teddit.ggc-project.de",
   "https://teddit.kavin.rocks",
-  "https://old.reddit.com", // desktop
-  "https://i.reddit.com", // mobile
-  "https://snew.notabug.io", // anti-censorship
+  "https://snew.notabug.io",
 ];
 const bypassPaths = /\/(gallery\/poll\/rpan\/settings\/topics)/;
 


### PR DESCRIPTION
Fixes #309, takes #304 one step further, and touches on valid points in #273.

This pull request removes old.reddit.com, and i.reddit.com from redirects. Additionally I've removed a couple dead links.

It appears counter-intuitive to me to have the very sites you're trying to direct users away from, be sites that you can redirect to. At first I thought this was a mistake, but upon further inspection is looks like this was a commit from Sep 2020 (https://github.com/SimonBrazell/privacy-redirect/commit/91002404546b4154f3fa20de77a9267dff7594de). 

This extension is a wonderful addition to my browsing experience, and I appreciate its good intentions. However, as it is listed on https://github.com/humanetech-community/awesome-humane-tech, has a Humane Tech button, and has the express interest in guiding users away from sites that harm users right to privacy, it makes sense that these sites should not be included.