### PR TITLE
remove down bibliogram servers

### DIFF
--- a/src/assets/javascripts/helpers/instagram.js
+++ b/src/assets/javascripts/helpers/instagram.js
@@ -8,9 +8,7 @@ const redirects = [
   "https://bibliogram.art",
   "https://bibliogram.snopyta.org",
   "https://bibliogram.pussthecat.org",
-  "https://bibliogram.nixnet.services",
   "https://bibliogram.ethibox.fr",
-  "https://bibliogram.hamster.dance",
   "https://insta.trom.tf",
   "https://bib.actionsack.com"
 ];


### PR DESCRIPTION
- https://www.ssllabs.com/ssltest/analyze.html?d=bibliogram.nixnet.services
- ````
  > dig bibliogram.hamster.dance

    ; <<>> DiG 9.16.24-RH <<>> bibliogram.hamster.dance
    ;; global options: +cmd
    ;; Got answer:
    ;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 44526
    ;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

    ;; OPT PSEUDOSECTION:
    ; EDNS: version: 0, flags:; udp: 65494
    ;; QUESTION SECTION:
    ;bibliogram.hamster.dance.	IN	A

    ;; AUTHORITY SECTION:
    hamster.dance.		3270	IN	SOA	dns1.registrar-servers.com. hostmaster.registrar-servers.com. 1641949933 43200 3600 604800 3601
   ````