### PR TITLE
Nitter: update an URL, remove another one

### DIFF
--- a/src/assets/javascripts/helpers/twitter.js
+++ b/src/assets/javascripts/helpers/twitter.js
@@ -19,7 +19,7 @@ const redirects = [
   "https://nitter.net",
   "https://nitter.snopyta.org",
   "https://nitter.42l.fr",
-  "https://nitter.nixnet.services",
+  "https://nitter:nitter@nitter.nixnet.services",
   "https://nitter.pussthecat.org",
   "https://nitter.dark.fail",
   "https://nitter.cattube.org",

--- a/src/assets/javascripts/helpers/twitter.js
+++ b/src/assets/javascripts/helpers/twitter.js
@@ -22,7 +22,6 @@ const redirects = [
   "https://nitter.nixnet.services",
   "https://nitter.pussthecat.org",
   "https://nitter.dark.fail",
-  "https://nitter.tedomum.net",
   "https://nitter.cattube.org",
   "https://nitter.fdn.fr",
   "https://nitter.1d4.us",

--- a/src/assets/javascripts/remove-twitter-sw.js
+++ b/src/assets/javascripts/remove-twitter-sw.js
@@ -4,7 +4,7 @@ const nitterInstances = [
   "https://nitter.net",
   "https://nitter.snopyta.org",
   "https://nitter.42l.fr",
-  "https://nitter.nixnet.services",
+  "https://nitter:nitter@nitter.nixnet.services",
   "https://nitter.pussthecat.org",
   "https://nitter.dark.fail",
   "https://nitter.cattube.org",

--- a/src/assets/javascripts/remove-twitter-sw.js
+++ b/src/assets/javascripts/remove-twitter-sw.js
@@ -7,7 +7,6 @@ const nitterInstances = [
   "https://nitter.nixnet.services",
   "https://nitter.pussthecat.org",
   "https://nitter.dark.fail",
-  "https://nitter.tedomum.net",
   "https://nitter.cattube.org",
   "https://nitter.fdn.fr",
   "https://nitter.1d4.us",


### PR DESCRIPTION
* remove nitter.tedomum.net: service [is closed](https://mastodon.tedomum.net/@tedomum/106272810211510860) since 2021-05-21
* update [nitter.nixnet.services](https://nixnet.services/blog/nitter-behind-http-basic-auth) URL