### PR TITLE
handle youtu.be for Freetube redirect

### DIFF
--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -274,6 +274,8 @@ function redirectYouTube(url, initiator, type) {
     return null;
   }
   if (useFreeTube && type === "main_frame") {
+    if (url.host === "youtu.be")
+      return `freetube://https://youtube.com/watch?v=${url.pathname.slice(1)}`
     return `freetube://${url}`;
   }
   // Apply settings


### PR DESCRIPTION
Freetube doens't handle case when videoID is just path. Freetube could handle this properly, but its much easier to fix and release this extension I guess.