### PR TITLE
Fix broken StartPage redirect URL. Fixes #324

### DIFF
--- a/src/assets/javascripts/helpers/google-search.js
+++ b/src/assets/javascripts/helpers/google-search.js
@@ -1,7 +1,7 @@
 const targets = /https?:\/\/(((www|maps)\.)?(google\.).*(\/search)|search\.(google\.).*)/;
 const redirects = [
   { link: "https://duckduckgo.com", q: "/" },
-  { link: "https://startpage.com", q: "/search/" },
+  { link: "https://startpage.com", q: "/sp/search" },
   { link: "https://www.ecosia.org", q: "/search" },
   { link: "https://www.qwant.com", q: "/" },
   { link: "https://www.mojeek.com", q: "/search" },


### PR DESCRIPTION
Updated the StartPage search URL. Now works correctly using the current URL. Fixes issue #324 