### PR TITLE
Fixed youtu.be redirects

### DIFF
--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -273,6 +273,13 @@ function redirectYouTube(url, initiator, type) {
   if (onlyEmbeddedVideo && type !== "sub_frame") {
     return null;
   }
+  if (url.host === "youtu.be" && !url.searchParams.has("v")) {
+    // add the video id of shortened if from the path, to the search params
+    // neither free tube nor invidious can work with shortened links till now
+    url.searchParams.append("v", url.pathname.replace("/", "")); // only works as long as video id's can't contain "/"
+    url.searchParams.delete("si");
+    url.pathname = "/watch";
+  }
   if (useFreeTube && type === "main_frame") {
     return `freetube://${url}`;
   }

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -273,15 +273,14 @@ function redirectYouTube(url, initiator, type) {
   if (onlyEmbeddedVideo && type !== "sub_frame") {
     return null;
   }
+  if (useFreeTube && type === "main_frame") {
+    return `freetube://${url}`;
+  }
   if (url.host === "youtu.be" && !url.searchParams.has("v")) {
     // add the video id of shortened if from the path, to the search params
-    // neither free tube nor invidious can work with shortened links till now
     url.searchParams.append("v", url.pathname.replace("/", "")); // only works as long as video id's can't contain "/"
     url.searchParams.delete("si");
     url.pathname = "/watch";
-  }
-  if (useFreeTube && type === "main_frame") {
-    return `freetube://${url}`;
   }
   // Apply settings
   if (alwaysProxy) {


### PR DESCRIPTION
When going to [https://youtu.be/dQw4w9WgXcQ](https://youtu.be/dQw4w9WgXcQ) and redirecting to invidious, the video doesn't open, because invidious can't handle it.

This is mentioned in #286 

# Current behaviour

`https://youtu.be/dQw4w9WgXcQ` --> `https://yt.artemislena.eu/`

# Wanted behaviour

`https://youtu.be/dQw4w9WgXcQ` --> `https://yt.artemislena.eu/watch?v=dQw4w9WgXcQ`

# Approach

- if it is a shortened link and it has not the search parameter `v` do the following
- set the search parameter `v` to the path, but strip all `/`
- set the path to `/watch`
- delete the search parameter `si`

I am unsure about the last step though. It looks cleaner if the search parameter `si` is gone, but I really don't know what it is used for, it didn't make any kind of different for me.