### PR TITLE
Fix for #438 - Support for X.com links

### DIFF
--- a/src/assets/javascripts/helpers/twitter.js
+++ b/src/assets/javascripts/helpers/twitter.js
@@ -5,8 +5,11 @@
   */
 const targets = [
   "twitter.com",
+  "x.com",
   "www.twitter.com",
+  "www.x.com",
   "mobile.twitter.com",
+  "mobile.x.com",
   "pbs.twimg.com",
   "video.twimg.com",
 ];


### PR DESCRIPTION
This PR adds the new domains used by twitter/X in their move towards the X rebranding.